### PR TITLE
Fixed the Reset() method

### DIFF
--- a/src/stable/js/tableexport.js
+++ b/src/stable/js/tableexport.js
@@ -506,7 +506,7 @@
              * @returns {TableExport} original TableExport instance
              */
             reset: function () {
-                return new TableExport(this.selectors, settings, true);
+                return new TableExport(this.selectors, this.settings, true);
             },
             /**
              * Remove the instance (i.e. caption containing the export buttons)


### PR DESCRIPTION
Hello, 

First of all, thanks a lot for your great plugin!

Reset method did not work: tableexport.js:502 Uncaught ReferenceError: settings is not defined(…)

I figured out that a 'this.' was missing before settings.