### PR TITLE
Fix dependency on xlsx-js; should be js-xlsx. 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bootstrap": "^3.3.7",
     "jquery": "^3.1.1",
-    "xlsx-js": "^0.8.7",
+    "js-xlsx": "^0.8.7",
     "file-saverjs": "^1.3.5",
     "blobjs": "^1.1.0"
   },


### PR DESCRIPTION
From SheetJS

>Our bower.json is configured to publish as js-xlsx. The manifest page appears to be correct.
xlsx-js points to a separate fork.
>It's likely that you either included both names in your bower.json, or a dependency pulls in the other version. I would check your local bower.json first.
>The correct name is noted in the README: https://github.com/sheetjs/js-xlsx#installation